### PR TITLE
Update 03-make-a-sound.org

### DIFF
--- a/03-make-a-sound.org
+++ b/03-make-a-sound.org
@@ -24,7 +24,7 @@ If we want to change the sound being generated, we can simply edit the body of t
 
 Evaluating the new snippet should result in the sound output being replaced with another sine wave of a lower pitch.
 
-If you want to stop the sound, you can simply remove the body to the proxy. It will default to ~nil~ which stops the sound:
+If you want to stop the sound, add 'nil' to the body parameter:
 
 #+BEGIN_SRC lisp
   (proxy :foo)

--- a/03-make-a-sound.org
+++ b/03-make-a-sound.org
@@ -27,7 +27,7 @@ Evaluating the new snippet should result in the sound output being replaced with
 If you want to stop the sound, add 'nil' to the body parameter:
 
 #+BEGIN_SRC lisp
-  (proxy :foo)
+  (proxy :foo nil) 
 #+END_SRC
 
 To restart the sound, just add the body back into the proxy and re-evaluate.


### PR DESCRIPTION
The proxy function no longer defaults to nil. nil must be added to the body of the function call.